### PR TITLE
申请将武汉同胞求助信息列入开源信息

### DIFF
--- a/README.md
+++ b/README.md
@@ -1601,3 +1601,7 @@ pdf 版本的备份，有日期、标题备查。来源不限于本站。
 #### [OpenSourceWuhan](https://weileizeng.github.io/OpenSourceWuhan/)
 
 一份在对抗肺炎期间的开源项目整理。
+
+#### [武汉同胞口罩下的呐喊](www.wuhancrisis.com) 
+
+记录整理了自二月三日起微博开设的 _肺炎患者求助_ 超级话题中内累计出现过几千份来自疫区的患者求助


### PR DESCRIPTION
自二月三日, 微博开设了 肺炎患者求助 超级话题后, 该频道内累计出现过几千份来自疫区的患者求助.
笔者使用爬虫收集了能收集到的微博, 并将每个人的求助和故事整理成该网站, 所有数据均来自微博平台.